### PR TITLE
blockchain: Goroutine bigger workload

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1149,18 +1149,9 @@ func (b *BlockChain) initChainState() error {
 
 		blockIndexBucket := dbTx.Metadata().Bucket(blockIndexBucketName)
 
-		// Determine how many blocks will be loaded into the index so we can
-		// allocate the right amount.
-		var blockCount int32
-		cursor := blockIndexBucket.Cursor()
-		for ok := cursor.First(); ok; ok = cursor.Next() {
-			blockCount++
-		}
-		blockNodes := make([]blockNode, blockCount)
-
 		var i int32
 		var lastNode *blockNode
-		cursor = blockIndexBucket.Cursor()
+		cursor := blockIndexBucket.Cursor()
 		for ok := cursor.First(); ok; ok = cursor.Next() {
 			header, status, err := deserializeBlockRow(cursor.Value())
 			if err != nil {
@@ -1193,7 +1184,7 @@ func (b *BlockChain) initChainState() error {
 
 			// Initialize the block node for the block, connect it,
 			// and add it to the block index.
-			node := &blockNodes[i]
+			node := new(blockNode)
 			initBlockNode(node, header, parent)
 			node.status = status
 			b.index.addNode(node)

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -111,6 +111,22 @@ func (entry *UtxoEntry) Clone() *UtxoEntry {
 	}
 }
 
+// NewUtxoEntry returns a new UtxoEntry built from the arguments.
+func NewUtxoEntry(
+	txOut *wire.TxOut, blockHeight int32, isCoinbase bool) *UtxoEntry {
+	var cbFlag txoFlags
+	if isCoinbase {
+		cbFlag |= tfCoinBase
+	}
+
+	return &UtxoEntry{
+		amount:      txOut.Value,
+		pkScript:    txOut.PkScript,
+		blockHeight: blockHeight,
+		packedFlags: cbFlag,
+	}
+}
+
 // UtxoViewpoint represents a view into the set of unspent transaction outputs
 // from a specific point of view in the chain.  For example, it could be for
 // the end of the main chain, some point in the history of the main chain, or

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -877,7 +877,6 @@ func CheckTransactionInputs(tx *btcutil.Tx, txHeight int32, utxoView *UtxoViewpo
 		return 0, nil
 	}
 
-	txHash := tx.Hash()
 	var totalSatoshiIn int64
 	for txInIndex, txIn := range tx.MsgTx().TxIn {
 		// Ensure the referenced input transaction is available.
@@ -954,7 +953,7 @@ func CheckTransactionInputs(tx *btcutil.Tx, txHeight int32, utxoView *UtxoViewpo
 	if totalSatoshiIn < totalSatoshiOut {
 		str := fmt.Sprintf("total value of all transaction inputs for "+
 			"transaction %v is %v which is less than the amount "+
-			"spent of %v", txHash, totalSatoshiIn, totalSatoshiOut)
+			"spent of %v", tx.Hash(), totalSatoshiIn, totalSatoshiOut)
 		return 0, ruleError(ErrSpendTooHigh, str)
 	}
 

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -8,6 +8,7 @@
 package btcjson
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -76,6 +77,37 @@ func NewCreateRawTransactionCmd(inputs []TransactionInput, amounts map[string]fl
 		Inputs:   inputs,
 		Amounts:  amounts,
 		LockTime: lockTime,
+	}
+}
+
+// FundRawTransactionOpts are the different options that can be passed to rawtransaction
+type FundRawTransactionOpts struct {
+	ChangeAddress          *string               `json:"changeAddress,omitempty"`
+	ChangePosition         *int                  `json:"changePosition,omitempty"`
+	ChangeType             *string               `json:"change_type,omitempty"`
+	IncludeWatching        *bool                 `json:"includeWatching,omitempty"`
+	LockUnspents           *bool                 `json:"lockUnspents,omitempty"`
+	FeeRate                *float64              `json:"feeRate,omitempty"` // BTC/kB
+	SubtractFeeFromOutputs []int                 `json:"subtractFeeFromOutputs,omitempty"`
+	Replaceable            *bool                 `json:"replaceable,omitempty"`
+	ConfTarget             *int                  `json:"conf_target,omitempty"`
+	EstimateMode           *EstimateSmartFeeMode `json:"estimate_mode,omitempty"`
+}
+
+// FundRawTransactionCmd defines the fundrawtransaction JSON-RPC command
+type FundRawTransactionCmd struct {
+	HexTx     string
+	Options   FundRawTransactionOpts
+	IsWitness *bool
+}
+
+// NewFundRawTransactionCmd returns a new instance which can be used to issue
+// a fundrawtransaction JSON-RPC command
+func NewFundRawTransactionCmd(serializedTx []byte, opts FundRawTransactionOpts, isWitness *bool) *FundRawTransactionCmd {
+	return &FundRawTransactionCmd{
+		HexTx:     hex.EncodeToString(serializedTx),
+		Options:   opts,
+		IsWitness: isWitness,
 	}
 }
 
@@ -856,6 +888,7 @@ func init() {
 
 	MustRegisterCmd("addnode", (*AddNodeCmd)(nil), flags)
 	MustRegisterCmd("createrawtransaction", (*CreateRawTransactionCmd)(nil), flags)
+	MustRegisterCmd("fundrawtransaction", (*FundRawTransactionCmd)(nil), flags)
 	MustRegisterCmd("decoderawtransaction", (*DecodeRawTransactionCmd)(nil), flags)
 	MustRegisterCmd("decodescript", (*DecodeScriptCmd)(nil), flags)
 	MustRegisterCmd("getaddednodeinfo", (*GetAddedNodeInfoCmd)(nil), flags)

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -368,6 +368,24 @@ func NewGetChainTipsCmd() *GetChainTipsCmd {
 	return &GetChainTipsCmd{}
 }
 
+// GetChainTxStatsCmd defines the getchaintxstats JSON-RPC command.
+type GetChainTxStatsCmd struct {
+	NBlocks   *int32
+	BlockHash *string
+}
+
+// NewGetChainTxStatsCmd returns a new instance which can be used to issue a
+// getchaintxstats JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetChainTxStatsCmd(nBlocks *int32, blockHash *string) *GetChainTxStatsCmd {
+	return &GetChainTxStatsCmd{
+		NBlocks:   nBlocks,
+		BlockHash: blockHash,
+	}
+}
+
 // GetConnectionCountCmd defines the getconnectioncount JSON-RPC command.
 type GetConnectionCountCmd struct{}
 
@@ -852,6 +870,7 @@ func init() {
 	MustRegisterCmd("getcfilter", (*GetCFilterCmd)(nil), flags)
 	MustRegisterCmd("getcfilterheader", (*GetCFilterHeaderCmd)(nil), flags)
 	MustRegisterCmd("getchaintips", (*GetChainTipsCmd)(nil), flags)
+	MustRegisterCmd("getchaintxstats", (*GetChainTxStatsCmd)(nil), flags)
 	MustRegisterCmd("getconnectioncount", (*GetConnectionCountCmd)(nil), flags)
 	MustRegisterCmd("getdifficulty", (*GetDifficultyCmd)(nil), flags)
 	MustRegisterCmd("getgenerate", (*GetGenerateCmd)(nil), flags)

--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -63,10 +63,15 @@ type CreateRawTransactionCmd struct {
 // NewCreateRawTransactionCmd returns a new instance which can be used to issue
 // a createrawtransaction JSON-RPC command.
 //
-// Amounts are in BTC.
+// Amounts are in BTC. Passing in nil and the empty slice as inputs is equivalent,
+// both gets interpreted as the empty slice.
 func NewCreateRawTransactionCmd(inputs []TransactionInput, amounts map[string]float64,
 	lockTime *int64) *CreateRawTransactionCmd {
-
+	// to make sure we're serializing this to the empty list and not null, we
+	// explicitly initialize the list
+	if inputs == nil {
+		inputs = []TransactionInput{}
+	}
 	return &CreateRawTransactionCmd{
 		Inputs:   inputs,
 		Amounts:  amounts,

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -438,6 +438,44 @@ func TestChainSvrCmds(t *testing.T) {
 			unmarshalled: &btcjson.GetChainTipsCmd{},
 		},
 		{
+			name: "getchaintxstats",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getchaintxstats")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetChainTxStatsCmd(nil, nil)
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"getchaintxstats","params":[],"id":1}`,
+			unmarshalled: &btcjson.GetChainTxStatsCmd{},
+		},
+		{
+			name: "getchaintxstats optional nblocks",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getchaintxstats", btcjson.Int32(1000))
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetChainTxStatsCmd(btcjson.Int32(1000), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getchaintxstats","params":[1000],"id":1}`,
+			unmarshalled: &btcjson.GetChainTxStatsCmd{
+				NBlocks: btcjson.Int32(1000),
+			},
+		},
+		{
+			name: "getchaintxstats optional nblocks and blockhash",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getchaintxstats", btcjson.Int32(1000), btcjson.String("0000afaf"))
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetChainTxStatsCmd(btcjson.Int32(1000), btcjson.String("0000afaf"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getchaintxstats","params":[1000,"0000afaf"],"id":1}`,
+			unmarshalled: &btcjson.GetChainTxStatsCmd{
+				NBlocks:   btcjson.Int32(1000),
+				BlockHash: btcjson.String("0000afaf"),
+			},
+		},
+		{
 			name: "getconnectioncount",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("getconnectioncount")

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -61,6 +61,21 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "createrawtransaction - no inputs",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("createrawtransaction", `[]`, `{"456":0.0123}`)
+			},
+			staticCmd: func() interface{} {
+				amounts := map[string]float64{"456": .0123}
+				return btcjson.NewCreateRawTransactionCmd(nil, amounts, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"createrawtransaction","params":[[],{"456":0.0123}],"id":1}`,
+			unmarshalled: &btcjson.CreateRawTransactionCmd{
+				Inputs:  []btcjson.TransactionInput{},
+				Amounts: map[string]float64{"456": .0123},
+			},
+		},
+		{
 			name: "createrawtransaction optional",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("createrawtransaction", `[{"txid":"123","vout":1}]`,

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -4,7 +4,14 @@
 
 package btcjson
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+)
 
 // GetBlockHeaderVerboseResult models the data from the getblockheader command when
 // the verbose flag is set.  When the verbose flag is not set, getblockheader
@@ -675,4 +682,51 @@ type EstimateSmartFeeResult struct {
 	FeeRate *float64 `json:"feerate,omitempty"`
 	Errors  []string `json:"errors,omitempty"`
 	Blocks  int64    `json:"blocks"`
+}
+
+var _ json.Unmarshaler = &FundRawTransactionResult{}
+
+type rawFundRawTransactionResult struct {
+	Transaction    string  `json:"hex"`
+	Fee            float64 `json:"fee"`
+	ChangePosition int     `json:"changepos"`
+}
+
+// FundRawTransactionResult is the result of the fundrawtransaction JSON-RPC call
+type FundRawTransactionResult struct {
+	Transaction    *wire.MsgTx
+	Fee            btcutil.Amount
+	ChangePosition int // the position of the added change output, or -1
+}
+
+// UnmarshalJSON unmarshals the result of the fundrawtransaction JSON-RPC call
+func (f *FundRawTransactionResult) UnmarshalJSON(data []byte) error {
+	var rawRes rawFundRawTransactionResult
+	if err := json.Unmarshal(data, &rawRes); err != nil {
+		return err
+	}
+
+	txBytes, err := hex.DecodeString(rawRes.Transaction)
+	if err != nil {
+		return err
+	}
+
+	var msgTx wire.MsgTx
+	witnessErr := msgTx.Deserialize(bytes.NewReader(txBytes))
+	if witnessErr != nil {
+		legacyErr := msgTx.DeserializeNoWitness(bytes.NewReader(txBytes))
+		if legacyErr != nil {
+			return legacyErr
+		}
+	}
+
+	fee, err := btcutil.NewAmount(rawRes.Fee)
+	if err != nil {
+		return err
+	}
+
+	f.Transaction = &msgTx
+	f.Fee = fee
+	f.ChangePosition = rawRes.ChangePosition
+	return nil
 }

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -107,6 +107,18 @@ type GetBlockVerboseTxResult struct {
 	NextHash      string        `json:"nextblockhash,omitempty"`
 }
 
+// GetChainTxStatsResult models the data from the getchaintxstats command.
+type GetChainTxStatsResult struct {
+	Time                   int64   `json:"time"`
+	TxCount                int64   `json:"txcount"`
+	WindowFinalBlockHash   string  `json:"window_final_block_hash"`
+	WindowFinalBlockHeight int32   `json:"window_final_block_height"`
+	WindowBlockCount       int32   `json:"window_block_count"`
+	WindowTxCount          int32   `json:"window_tx_count"`
+	WindowInterval         int32   `json:"window_interval"`
+	TxRate                 float64 `json:"txrate"`
+}
+
 // CreateMultiSigResult models the data returned from the createmultisig
 // command.
 type CreateMultiSigResult struct {

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -307,6 +307,79 @@ func (c *Client) GetBlockCount() (int64, error) {
 	return c.GetBlockCountAsync().Receive()
 }
 
+// FutureGetChainTxStatsResult is a future promise to deliver the result of a
+// GetChainTxStatsAsync RPC invocation (or an applicable error).
+type FutureGetChainTxStatsResult chan *response
+
+// Receive waits for the response promised by the future and returns transaction statistics
+func (r FutureGetChainTxStatsResult) Receive() (*btcjson.GetChainTxStatsResult, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var chainTxStats btcjson.GetChainTxStatsResult
+	err = json.Unmarshal(res, &chainTxStats)
+	if err != nil {
+		return nil, err
+	}
+
+	return &chainTxStats, nil
+}
+
+// GetChainTxStatsAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See GetChainTxStats for the blocking version and more details.
+func (c *Client) GetChainTxStatsAsync() FutureGetChainTxStatsResult {
+	cmd := btcjson.NewGetChainTxStatsCmd(nil, nil)
+	return c.sendCmd(cmd)
+}
+
+// GetChainTxStatsNBlocksAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See GetChainTxStatsNBlocks for the blocking version and more details.
+func (c *Client) GetChainTxStatsNBlocksAsync(nBlocks int32) FutureGetChainTxStatsResult {
+	cmd := btcjson.NewGetChainTxStatsCmd(&nBlocks, nil)
+	return c.sendCmd(cmd)
+}
+
+// GetChainTxStatsNBlocksBlockHashAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See GetChainTxStatsNBlocksBlockHash for the blocking version and more details.
+func (c *Client) GetChainTxStatsNBlocksBlockHashAsync(nBlocks int32, blockHash chainhash.Hash) FutureGetChainTxStatsResult {
+	hash := blockHash.String()
+	cmd := btcjson.NewGetChainTxStatsCmd(&nBlocks, &hash)
+	return c.sendCmd(cmd)
+}
+
+// GetChainTxStats returns statistics about the total number and rate of transactions in the chain.
+//
+// Size of the window is one month and it ends at chain tip.
+func (c *Client) GetChainTxStats() (*btcjson.GetChainTxStatsResult, error) {
+	return c.GetChainTxStatsAsync().Receive()
+}
+
+// GetChainTxStatsNBlocks returns statistics about the total number and rate of transactions in the chain.
+//
+// The argument specifies size of the window in number of blocks. The window ends at chain tip.
+func (c *Client) GetChainTxStatsNBlocks(nBlocks int32) (*btcjson.GetChainTxStatsResult, error) {
+	return c.GetChainTxStatsNBlocksAsync(nBlocks).Receive()
+}
+
+// GetChainTxStatsNBlocksBlockHash returns statistics about the total number and rate of transactions in the chain.
+//
+// First argument specifies size of the window in number of blocks.
+// Second argument is the hash of the block that ends the window.
+func (c *Client) GetChainTxStatsNBlocksBlockHash(nBlocks int32, blockHash chainhash.Hash) (*btcjson.GetChainTxStatsResult, error) {
+	return c.GetChainTxStatsNBlocksBlockHashAsync(nBlocks, blockHash).Receive()
+}
+
 // FutureGetDifficultyResult is a future promise to deliver the result of a
 // GetDifficultyAsync RPC invocation (or an applicable error).
 type FutureGetDifficultyResult chan *response

--- a/rpcclient/cookiefile.go
+++ b/rpcclient/cookiefile.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017 The Namecoin developers
+// Copyright (c) 2019 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package rpcclient
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+)
+
+func readCookieFile(path string) (username, password string, err error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	s := strings.TrimSpace(string(b))
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		err = fmt.Errorf("malformed cookie file")
+		return
+	}
+
+	username, password = parts[0], parts[1]
+	return
+}
+
+func cookieRetriever(path string) func() (username, password string, err error) {
+	lastCheckTime := time.Time{}
+	lastModTime := time.Time{}
+
+	curUsername, curPassword := "", ""
+	var curError error
+
+	doUpdate := func() {
+		if !lastCheckTime.IsZero() && time.Now().Before(lastCheckTime.Add(30*time.Second)) {
+			return
+		}
+
+		lastCheckTime = time.Now()
+
+		st, err := os.Stat(path)
+		if err != nil {
+			curError = err
+			return
+		}
+
+		modTime := st.ModTime()
+		if !modTime.Equal(lastModTime) {
+			lastModTime = modTime
+			curUsername, curPassword, curError = readCookieFile(path)
+		}
+	}
+
+	return func() (username, password string, err error) {
+		doUpdate()
+		return curUsername, curPassword, curError
+	}
+}

--- a/rpcclient/cookiefile.go
+++ b/rpcclient/cookiefile.go
@@ -6,18 +6,27 @@
 package rpcclient
 
 import (
+	"bufio"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
 func readCookieFile(path string) (username, password string, err error) {
-	b, err := ioutil.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return
 	}
+	defer f.Close()
 
-	s := strings.TrimSpace(string(b))
+	scanner := bufio.NewScanner(f)
+	scanner.Scan()
+	err = scanner.Err()
+	if err != nil {
+		return
+	}
+	s := scanner.Text()
+
 	parts := strings.SplitN(s, ":", 2)
 	if len(parts) != 2 {
 		err = fmt.Errorf("malformed cookie file")

--- a/rpcclient/cookiefile.go
+++ b/rpcclient/cookiefile.go
@@ -8,9 +8,7 @@ package rpcclient
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
-	"time"
 )
 
 func readCookieFile(path string) (username, password string, err error) {
@@ -28,37 +26,4 @@ func readCookieFile(path string) (username, password string, err error) {
 
 	username, password = parts[0], parts[1]
 	return
-}
-
-func cookieRetriever(path string) func() (username, password string, err error) {
-	lastCheckTime := time.Time{}
-	lastModTime := time.Time{}
-
-	curUsername, curPassword := "", ""
-	var curError error
-
-	doUpdate := func() {
-		if !lastCheckTime.IsZero() && time.Now().Before(lastCheckTime.Add(30*time.Second)) {
-			return
-		}
-
-		lastCheckTime = time.Now()
-
-		st, err := os.Stat(path)
-		if err != nil {
-			curError = err
-			return
-		}
-
-		modTime := st.ModTime()
-		if !modTime.Equal(lastModTime) {
-			lastModTime = modTime
-			curUsername, curPassword, curError = readCookieFile(path)
-		}
-	}
-
-	return func() (username, password string, err error) {
-		doUpdate()
-		return curUsername, curPassword, curError
-	}
 }

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1171,12 +1171,12 @@ type ConnConfig struct {
 // path is configured; if not, it will be the user-configured username and
 // passphrase.
 func (config *ConnConfig) getAuth() (username, passphrase string, err error) {
-	// If cookie auth isn't in use, just use the supplied
-	// username/passphrase.
-	if config.CookiePath == "" {
+	// Try username+passphrase auth first.
+	if config.Pass != "" {
 		return config.User, config.Pass, nil
 	}
 
+	// If no username or passphrase is set, try cookie auth.
 	return config.retrieveCookie()
 }
 

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -205,6 +205,47 @@ func (c *Client) DecodeRawTransaction(serializedTx []byte) (*btcjson.TxRawResult
 	return c.DecodeRawTransactionAsync(serializedTx).Receive()
 }
 
+// FutureFundRawTransactionResult is a future promise to deliver the result
+// of a FutureFundRawTransactionAsync RPC invocation (or an applicable error).
+type FutureFundRawTransactionResult chan *response
+
+// Receive waits for the response promised by the future and returns information
+// about a funding attempt
+func (r FutureFundRawTransactionResult) Receive() (*btcjson.FundRawTransactionResult, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var marshalled btcjson.FundRawTransactionResult
+	if err := json.Unmarshal(res, &marshalled); err != nil {
+		return nil, err
+	}
+
+	return &marshalled, nil
+}
+
+// FundRawTransactionAsync returns an instance of a type that can be used to
+// get the result of the RPC at some future time by invoking the Receive
+// function on the returned instance.
+//
+// See FundRawTransaction for the blocking version and more details.
+func (c *Client) FundRawTransactionAsync(tx *wire.MsgTx, opts btcjson.FundRawTransactionOpts, isWitness *bool) FutureFundRawTransactionResult {
+	var txBuf bytes.Buffer
+	if err := tx.Serialize(&txBuf); err != nil {
+		return newFutureError(err)
+	}
+
+	cmd := btcjson.NewFundRawTransactionCmd(txBuf.Bytes(), opts, isWitness)
+	return c.sendCmd(cmd)
+}
+
+// FundRawTransaction returns the result of trying to fund the given transaction with
+// funds from the node wallet
+func (c *Client) FundRawTransaction(tx *wire.MsgTx, opts btcjson.FundRawTransactionOpts, isWitness *bool) (*btcjson.FundRawTransactionResult, error) {
+	return c.FundRawTransactionAsync(tx, opts, isWitness).Receive()
+}
+
 // FutureCreateRawTransactionResult is a future promise to deliver the result
 // of a CreateRawTransactionAsync RPC invocation (or an applicable error).
 type FutureCreateRawTransactionResult chan *response

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -261,7 +261,8 @@ func (c *Client) CreateRawTransactionAsync(inputs []btcjson.TransactionInput,
 }
 
 // CreateRawTransaction returns a new transaction spending the provided inputs
-// and sending to the provided addresses.
+// and sending to the provided addresses. If the inputs are either nil or an
+// empty slice, it is interpreted as an empty slice.
 func (c *Client) CreateRawTransaction(inputs []btcjson.TransactionInput,
 	amounts map[btcutil.Address]btcutil.Amount, lockTime *int64) (*wire.MsgTx, error) {
 


### PR DESCRIPTION
Gets rid of the expensive goroutines calls per TXIN. This ends up with the scheduler choking. Utreexo code in my branch currently calls goroutines per TX but with btcd this should be making the verification slower.